### PR TITLE
checksum: only open in bytes mode for checksum

### DIFF
--- a/lib/python/rose/checksum.py
+++ b/lib/python/rose/checksum.py
@@ -124,7 +124,19 @@ def guess_checksum_algorithm(checksum):
 
 
 def _get_hexdigest(algorithm, source):
-    """Load content of source into an hash object, and return its hexdigest."""
+    """Load content of source into an hash object, and return its hexdigest.
+
+    Args:
+        algorithm (str):
+            Hash algorithm as namespaced in hashlib.
+        source (str, file):
+            The item to hexdigest, can be:
+
+            * Path to a file (``str``).
+            * Path to a directory (``str``).
+            * A file object ``readable`` in bytes mode.
+
+    """
     if hasattr(source, "read"):
         handle = source
     else:
@@ -142,10 +154,7 @@ def _get_hexdigest(algorithm, source):
         bytes_ = handle.read(f_bsize)
         if not bytes_:
             break
-        if isinstance(bytes_, bytes):
-            hashobj.update(bytes_)
-        else:
-            hashobj.update(bytes_.encode(encoding='UTF-8'))
+        hashobj.update(bytes_)
     handle.close()
 
     return hashobj.hexdigest()

--- a/lib/python/rose/config_processors/fileinstall.py
+++ b/lib/python/rose/config_processors/fileinstall.py
@@ -34,7 +34,7 @@ from rose.scheme_handler import SchemeHandlersManager
 import shlex
 from shutil import rmtree
 import sqlite3
-from io import StringIO
+from io import BytesIO
 import sys
 from tempfile import mkdtemp
 from urllib.parse import urlparse
@@ -375,7 +375,12 @@ class ConfigProcessorForFile(ConfigProcessorBase):
     def _source_pull(self, source, conf_tree, work_dir):
         """Pulls a source to its cache in the work directory."""
         source.cache = os.path.join(
-            work_dir, get_checksum_func()(StringIO(source.name)))
+            work_dir,
+            # checksum the source name (not it's contents).
+            # this is a cheap solution to provide a unique, repeatable
+            # and filesystem safe identifier for a source name (which could be
+            # a url).
+            get_checksum_func()(BytesIO(source.name.encode())))
         return self.loc_handlers_manager.pull(source, conf_tree)
 
     def _target_install(self, target, conf_tree, work_dir):


### PR DESCRIPTION
Swap a `StringIO` for a `BytesIO` allowing us to remove an unnecessary `if bytes` branch.